### PR TITLE
:money_with_wings: Add Assert, Disprove, Payout transactions

### DIFF
--- a/bitcoin-testscripts/src/lib.rs
+++ b/bitcoin-testscripts/src/lib.rs
@@ -4,7 +4,7 @@ pub mod int_mul_karatsuba;
 pub mod int_mul_windowed;
 pub mod sha256;
 pub mod square_fibonacci;
-pub mod u29mul;
+pub mod u32mul;
 
 #[cfg(test)]
 pub mod tests;

--- a/bitcoin-testscripts/src/u29mul.rs
+++ b/bitcoin-testscripts/src/u29mul.rs
@@ -2,7 +2,10 @@
 //! for performing the multiplication of two large integers
 //! (exceeding standard Bitcoin 31-bit integers)
 
-use bitcoin_splitter::split::{core::SplitType, script::{IOPair, SplitResult, SplitableScript}};
+use bitcoin_splitter::split::{
+    core::SplitType,
+    script::{IOPair, SplitResult, SplitableScript},
+};
 use bitcoin_utils::treepp::*;
 use bitcoin_window_mul::{
     bigint::implementation::NonNativeBigIntImpl,
@@ -67,10 +70,7 @@ impl SplitableScript<{ INPUT_SIZE }, { OUTPUT_SIZE }> for U29MulScript {
         }
     }
 
-    fn default_split(
-        input: Script,
-        split_type: SplitType,
-    ) -> SplitResult {
+    fn default_split(input: Script, split_type: SplitType) -> SplitResult {
         Self::split(input, split_type, 300)
     }
 }

--- a/bitcoin-testscripts/src/u29mul.rs
+++ b/bitcoin-testscripts/src/u29mul.rs
@@ -2,7 +2,7 @@
 //! for performing the multiplication of two large integers
 //! (exceeding standard Bitcoin 31-bit integers)
 
-use bitcoin_splitter::split::script::{IOPair, SplitableScript};
+use bitcoin_splitter::split::{core::SplitType, script::{IOPair, SplitResult, SplitableScript}};
 use bitcoin_utils::treepp::*;
 use bitcoin_window_mul::{
     bigint::implementation::NonNativeBigIntImpl,
@@ -65,6 +65,13 @@ impl SplitableScript<{ INPUT_SIZE }, { OUTPUT_SIZE }> for U29MulScript {
             },
             output: U58::OP_PUSH_U32LESLICE(&product.to_u32_digits()),
         }
+    }
+
+    fn default_split(
+        input: Script,
+        split_type: SplitType,
+    ) -> SplitResult {
+        Self::split(input, split_type, 300)
     }
 }
 

--- a/bitcoin-testscripts/src/u32mul.rs
+++ b/bitcoin-testscripts/src/u32mul.rs
@@ -16,36 +16,36 @@ use num_bigint::{BigUint, RandomBits};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
-pub type U29 = NonNativeBigIntImpl<29, 29>;
-pub type U58 = NonNativeBigIntImpl<58, 29>;
+pub type U32 = NonNativeBigIntImpl<32, 29>;
+pub type U64 = NonNativeBigIntImpl<64, 29>;
 
 /// Script that performs the addition of two 255-bit numbers
-pub struct U29MulScript;
+pub struct U32MulScript;
 
 /// Input size is double the number of limbs of U254 since we are multiplying two numbers
-const INPUT_SIZE: usize = 2 * U29::N_LIMBS;
+const INPUT_SIZE: usize = 2 * U32::N_LIMBS;
 /// Output size is the number of limbs of U508
-const OUTPUT_SIZE: usize = U58::N_LIMBS;
+const OUTPUT_SIZE: usize = U64::N_LIMBS;
 
-impl SplitableScript<{ INPUT_SIZE }, { OUTPUT_SIZE }> for U29MulScript {
+impl SplitableScript<{ INPUT_SIZE }, { OUTPUT_SIZE }> for U32MulScript {
     fn script() -> Script {
-        U29::OP_WIDENINGMUL::<U58>()
+        U32::OP_WIDENINGMUL::<U64>()
     }
 
     fn generate_valid_io_pair() -> IOPair<{ INPUT_SIZE }, { OUTPUT_SIZE }> {
         let mut prng = ChaCha20Rng::seed_from_u64(0);
 
         // Generate two random 254-bit numbers and calculate their sum
-        let num_1: BigUint = prng.sample(RandomBits::new(29));
+        let num_1: BigUint = prng.sample(RandomBits::new(32));
         let num_2: BigUint = prng.sample(RandomBits::new(29));
         let product: BigUint = num_1.clone() * num_2.clone();
 
         IOPair {
             input: script! {
-                { U29::OP_PUSH_U32LESLICE(&num_1.to_u32_digits()) }
-                { U29::OP_PUSH_U32LESLICE(&num_2.to_u32_digits()) }
+                { U32::OP_PUSH_U32LESLICE(&num_1.to_u32_digits()) }
+                { U32::OP_PUSH_U32LESLICE(&num_2.to_u32_digits()) }
             },
-            output: U58::OP_PUSH_U32LESLICE(&product.to_u32_digits()),
+            output: U64::OP_PUSH_U32LESLICE(&product.to_u32_digits()),
         }
     }
 
@@ -63,10 +63,10 @@ impl SplitableScript<{ INPUT_SIZE }, { OUTPUT_SIZE }> for U29MulScript {
 
         IOPair {
             input: script! {
-                { U29::OP_PUSH_U32LESLICE(&num_1.to_u32_digits()) }
-                { U29::OP_PUSH_U32LESLICE(&num_2.to_u32_digits()) }
+                { U32::OP_PUSH_U32LESLICE(&num_1.to_u32_digits()) }
+                { U32::OP_PUSH_U32LESLICE(&num_2.to_u32_digits()) }
             },
-            output: U58::OP_PUSH_U32LESLICE(&product.to_u32_digits()),
+            output: U64::OP_PUSH_U32LESLICE(&product.to_u32_digits()),
         }
     }
 
@@ -84,20 +84,20 @@ mod tests {
 
     #[test]
     fn test_verify() {
-        assert!(U29MulScript::verify_random());
+        assert!(U32MulScript::verify_random());
     }
 
     #[test]
     fn test_naive_split_correctness() {
         // Generating a random valid input for the script and the script itself
-        let IOPair { input, output } = U29MulScript::generate_valid_io_pair();
+        let IOPair { input, output } = U32MulScript::generate_valid_io_pair();
         assert!(
-            U29MulScript::verify(input.clone(), output.clone()),
+            U32MulScript::verify(input.clone(), output.clone()),
             "input/output is not correct"
         );
 
         // Splitting the script into shards
-        let split_result = U29MulScript::default_split(input.clone(), SplitType::ByInstructions);
+        let split_result = U32MulScript::default_split(input.clone(), SplitType::ByInstructions);
 
         // Now, we are going to concatenate all the shards and verify that the script is also correct
         let verification_script = script! {
@@ -108,7 +108,7 @@ mod tests {
             { output }
 
             // Now, we need to verify that the output is correct.
-            for i in (0..U29MulScript::OUTPUT_SIZE).rev() {
+            for i in (0..U32MulScript::OUTPUT_SIZE).rev() {
                 // { <a_1> <a_2> ... <a_n> <b_1> <b_2> ... <b_n> } <- we need to push element <a_n> to the top of the stack
                 { i+1 } OP_ROLL
                 OP_EQUALVERIFY
@@ -124,10 +124,10 @@ mod tests {
     #[test]
     fn test_naive_split() {
         // First, we generate the pair of input and output scripts
-        let IOPair { input, output } = U29MulScript::generate_valid_io_pair();
+        let IOPair { input, output } = U32MulScript::generate_valid_io_pair();
 
         // Splitting the script into shards
-        let split_result = U29MulScript::default_split(input, SplitType::ByInstructions);
+        let split_result = U32MulScript::default_split(input, SplitType::ByInstructions);
 
         for shard in split_result.shards.iter() {
             println!("Shard: {:?}", shard.len());
@@ -146,7 +146,7 @@ mod tests {
         let verification_script = script! {
             { stack_to_script(&last_state.stack) }
             { output }
-            { U58::OP_EQUAL(0, 1) }
+            { U64::OP_EQUAL(0, 1) }
         };
 
         let result = execute_script(verification_script);
@@ -170,10 +170,10 @@ mod tests {
     #[ignore = "too-large computation, run separately"]
     fn test_fuzzy_split() {
         // First, we generate the pair of input and output scripts
-        let IOPair { input, output } = U29MulScript::generate_valid_io_pair();
+        let IOPair { input, output } = U32MulScript::generate_valid_io_pair();
 
         // Splitting the script into shards
-        let split_result = U29MulScript::fuzzy_split(input, SplitType::ByInstructions);
+        let split_result = U32MulScript::fuzzy_split(input, SplitType::ByInstructions);
 
         for shard in split_result.shards.iter() {
             println!("Shard: {:?}", shard.len());
@@ -192,7 +192,7 @@ mod tests {
         let verification_script = script! {
             { stack_to_script(&last_state.stack) }
             { output }
-            { U58::OP_EQUAL(0, 1) }
+            { U64::OP_EQUAL(0, 1) }
         };
 
         let result = execute_script(verification_script);

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,4 +36,6 @@ rand        = { version = "0.8.5", default-features = false, features = ["min_co
 rand_chacha = "0.3.1"
 ark-std     = "0.4.0"
 konst       = "0.3.9"
+once_cell = "1.19.0"
+eyre = "0.6.12"
 

--- a/core/src/assert/mod.rs
+++ b/core/src/assert/mod.rs
@@ -1,1 +1,285 @@
+use std::{collections::HashMap, iter, marker::PhantomData};
 
+use bitcoin::{
+    absolute::LockTime,
+    ecdsa,
+    key::{Keypair, Secp256k1},
+    psbt::Input,
+    relative::Height,
+    secp256k1::{All, SecretKey},
+    sighash::{Prevouts, SighashCache},
+    taproot::{LeafVersion, TaprootBuilder, TaprootSpendInfo},
+    transaction::Version,
+    Amount, EcdsaSighashType, OutPoint, Psbt, Sequence, TapSighashType, Transaction, TxIn, TxOut,
+    Txid, Witness, XOnlyPublicKey,
+};
+use bitcoin_splitter::split::script::SplitableScript;
+
+use crate::{assert::payout_script::PayoutScript, UNSPENDABLE_KEY, treepp::*};
+
+use crate::disprove::{form_disprove_scripts, DisproveScript};
+
+pub mod payout_script;
+
+const DISPROVE_SCRIPT_WEIGHT: u32 = 1;
+const PAYOUT_SCRIPT_WEIGHT: u32 = 5;
+
+pub struct AssertTransaction<const I: usize, const O: usize, S: SplitableScript<I, O>> {
+    /// Input of the program.
+    pub input: Script,
+
+    /// Operator's public key.
+    pub operator_pubkey: XOnlyPublicKey,
+
+    /// Amount staked for assertion.
+    pub amount: Amount,
+
+    pub disprove_scripts: Vec<DisproveScript>,
+    pub payout_script: PayoutScript,
+
+    /// Program this transaction asserts.
+    __program: PhantomData<S>,
+}
+
+impl<const I: usize, const O: usize, S: SplitableScript<I, O>> Clone
+    for AssertTransaction<I, O, S>
+{
+    fn clone(&self) -> Self {
+        Self {
+            input: self.input.clone(),
+            operator_pubkey: self.operator_pubkey,
+            amount: self.amount,
+            disprove_scripts: self.disprove_scripts.clone(),
+            payout_script: self.payout_script.clone(),
+            __program: self.__program,
+        }
+    }
+}
+
+pub struct Options {
+    pub payout_locktime: Height,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            payout_locktime: payout_script::LOCKTIME.into(),
+        }
+    }
+}
+
+impl<const I: usize, const O: usize, S: SplitableScript<I, O>> AssertTransaction<I, O, S> {
+    /// Construct new Assert transaction.
+    pub fn new(input: Script, operator_pubkey: XOnlyPublicKey, amount: Amount) -> Self {
+        Self::with_options(input, operator_pubkey, amount, Default::default())
+    }
+
+    pub fn with_options(
+        input: Script,
+        operator_pubkey: XOnlyPublicKey,
+        amount: Amount,
+        options: Options,
+    ) -> Self {
+        let disprove_scripts = form_disprove_scripts::<I, O, S>(input.clone());
+        let payout_script = PayoutScript::with_locktime(operator_pubkey, options.payout_locktime);
+        Self {
+            input,
+            operator_pubkey,
+            amount,
+            disprove_scripts,
+            payout_script,
+            __program: PhantomData,
+        }
+    }
+
+    /// Return partially signed transaction with P2TR output with all disprove
+    /// scripts and payout script.
+    pub fn into_psbt(self, ctx: &Secp256k1<All>) -> Psbt {
+        let txout = self.txout(ctx);
+
+        let tx = Transaction {
+            version: Version::ONE,
+            lock_time: LockTime::ZERO,
+            input: vec![],
+            output: vec![txout],
+        };
+
+        Psbt::from_unsigned_tx(tx)
+            .expect("witness and script_sigs are not filled, so this should never panic")
+    }
+
+    pub fn txout(self, ctx: &Secp256k1<All>) -> TxOut {
+        let taptree = self.form_taptree(ctx);
+
+        self.assert_taproot_output(&taptree)
+    }
+
+    fn assert_taproot_output(&self, taptree: &TaprootSpendInfo) -> TxOut {
+        let script_pubkey = Script::new_p2tr_tweaked(taptree.output_key());
+
+        TxOut {
+            value: self.amount,
+            script_pubkey,
+        }
+    }
+
+    fn form_taptree(&self, ctx: &Secp256k1<All>) -> TaprootSpendInfo {
+        let scripts_with_weights =
+            iter::once((PAYOUT_SCRIPT_WEIGHT, self.payout_script.clone().to_script())).chain(
+                self.disprove_scripts
+                    .clone()
+                    .into_iter()
+                    .map(|script| (DISPROVE_SCRIPT_WEIGHT, script.script_pubkey)),
+            );
+
+        TaprootBuilder::with_huffman_tree(scripts_with_weights)
+            .expect("Weights are low, and number of scripts shoudn't create the tree greater than 128 in depth (I believe)")
+            .finalize(ctx, *UNSPENDABLE_KEY)
+            .expect("Scripts and keys should be valid")
+    }
+
+    /// Create Payout transaction which spends first output of Assert
+    /// transaction using Payout script path.
+    pub fn payout_transaction(
+        &self,
+        ctx: &Secp256k1<All>,
+        txout: TxOut,
+        txid: Txid,
+        operator_seckey: &SecretKey,
+    ) -> eyre::Result<Transaction> {
+        let taptree = self.form_taptree(ctx);
+
+        let script = self.payout_script.to_script();
+
+        let mut tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::new(txid, 0),
+                script_sig: Script::new(),
+                sequence: Sequence::from_height(self.payout_script.locktime.value()),
+                witness: Witness::new(),
+            }],
+            output: vec![txout],
+        };
+
+        let leaf_hash = script.tapscript_leaf_hash();
+        let prev_txout = self.assert_taproot_output(&taptree);
+
+        let sighash = SighashCache::new(&tx).taproot_script_spend_signature_hash(
+            0,
+            &Prevouts::All(&[prev_txout]),
+            leaf_hash,
+            TapSighashType::Default,
+        )?;
+
+        let signature = ctx.sign_schnorr(
+            &sighash.into(),
+            &Keypair::from_secret_key(ctx, operator_seckey),
+        );
+
+        let control_block = &taptree
+            .control_block(&(script.clone(), LeafVersion::TapScript))
+            .unwrap();
+
+        let mut witness = Witness::new();
+        witness.push(signature.as_ref());
+        witness.push(self.operator_pubkey.serialize());
+        witness.push(script.as_bytes());
+        witness.push(control_block.serialize());
+
+        tx.input[0].witness = witness;
+
+        Ok(tx)
+    }
+
+    /// Create Payout transaction which spends first output of Assert
+    /// transaction using Payout script path.
+    pub fn disprove_transactions(
+        &self,
+        ctx: &Secp256k1<All>,
+        txout: TxOut,
+        txid: Txid,
+    ) -> eyre::Result<HashMap<DisproveScript, Transaction>> {
+        let taptree = self.form_taptree(ctx);
+        let mut map = HashMap::with_capacity(self.disprove_scripts.len());
+
+        for disprove in &self.disprove_scripts {
+            let script = disprove.script_pubkey.clone();
+            let mut witness = Witness::new();
+
+            for elem in disprove.witness_elements() {
+                witness.push(elem);
+            }
+
+            let control_block = &taptree
+                .control_block(&(script.clone(), LeafVersion::TapScript))
+                .unwrap();
+
+            witness.push(script.as_bytes());
+            witness.push(control_block.serialize());
+
+            let tx = Transaction {
+                version: Version::ONE,
+                lock_time: LockTime::ZERO,
+                input: vec![TxIn {
+                    previous_output: OutPoint::new(txid, 0),
+                    script_sig: Script::new(),
+                    sequence: Sequence::ZERO,
+                    witness,
+                }],
+                output: vec![txout.clone()],
+            };
+
+            map.insert(disprove.clone(), tx);
+        }
+
+        Ok(map)
+    }
+
+    /// Create transaction which spends provided utxo (assuming that it's the
+    /// P2WPKH one) signed with provided key.
+    pub fn spend_p2wpkh_input_tx(
+        self,
+        ctx: &Secp256k1<All>,
+        secret_key: &SecretKey,
+        txout: TxOut,
+        outpoint: OutPoint,
+    ) -> eyre::Result<Transaction> {
+        let mut psbt = self.into_psbt(ctx);
+
+        psbt.unsigned_tx.input.push(TxIn {
+            previous_output: outpoint,
+            script_sig: Script::new(),
+            sequence: Sequence::ZERO,
+            witness: Witness::new(),
+        });
+
+        let sighash = SighashCache::new(&psbt.unsigned_tx).p2wpkh_signature_hash(
+            0,
+            &txout.script_pubkey,
+            txout.value,
+            EcdsaSighashType::All,
+        )?;
+
+        let signature = ctx.sign_ecdsa(&sighash.into(), secret_key);
+
+        let mut witness = Witness::new();
+
+        // for disprove in disprove_scripts {
+        //     for elem in disprove.witness_elements() {
+        //         witness.push(elem);
+        //     }
+        // }
+        witness.push_ecdsa_signature(&ecdsa::Signature::sighash_all(signature));
+        witness.push(secret_key.public_key(ctx).serialize());
+
+        psbt.inputs.push(Input {
+            witness_utxo: Some(txout),
+            final_script_witness: Some(witness),
+            ..Default::default()
+        });
+
+        psbt.extract_tx().map_err(Into::into)
+    }
+}

--- a/core/src/assert/mod.rs
+++ b/core/src/assert/mod.rs
@@ -15,7 +15,7 @@ use bitcoin::{
 };
 use bitcoin_splitter::split::script::SplitableScript;
 
-use crate::{assert::payout_script::PayoutScript, UNSPENDABLE_KEY, treepp::*};
+use crate::{assert::payout_script::PayoutScript, disprove::form_disprove_scripts_distorted, treepp::*, UNSPENDABLE_KEY};
 
 use crate::disprove::{form_disprove_scripts, DisproveScript};
 
@@ -90,6 +90,24 @@ impl<const I: usize, const O: usize, S: SplitableScript<I, O>> AssertTransaction
             payout_script,
             __program: PhantomData,
         }
+    }
+
+    pub fn with_options_distorted(
+        input: Script,
+        operator_pubkey: XOnlyPublicKey,
+        amount: Amount,
+        options: Options,
+    ) -> (Self, usize) {
+        let (disprove_scripts, idx) = form_disprove_scripts_distorted::<I, O, S>(input.clone());
+        let payout_script = PayoutScript::with_locktime(operator_pubkey, options.payout_locktime);
+        (Self {
+            input,
+            operator_pubkey,
+            amount,
+            disprove_scripts,
+            payout_script,
+            __program: PhantomData,
+        }, idx)
     }
 
     /// Return partially signed transaction with P2TR output with all disprove

--- a/core/src/assert/mod.rs
+++ b/core/src/assert/mod.rs
@@ -15,7 +15,10 @@ use bitcoin::{
 };
 use bitcoin_splitter::split::script::SplitableScript;
 
-use crate::{assert::payout_script::PayoutScript, disprove::form_disprove_scripts_distorted, treepp::*, UNSPENDABLE_KEY};
+use crate::{
+    assert::payout_script::PayoutScript, disprove::form_disprove_scripts_distorted, treepp::*,
+    UNSPENDABLE_KEY,
+};
 
 use crate::disprove::{form_disprove_scripts, DisproveScript};
 
@@ -100,14 +103,17 @@ impl<const I: usize, const O: usize, S: SplitableScript<I, O>> AssertTransaction
     ) -> (Self, usize) {
         let (disprove_scripts, idx) = form_disprove_scripts_distorted::<I, O, S>(input.clone());
         let payout_script = PayoutScript::with_locktime(operator_pubkey, options.payout_locktime);
-        (Self {
-            input,
-            operator_pubkey,
-            amount,
-            disprove_scripts,
-            payout_script,
-            __program: PhantomData,
-        }, idx)
+        (
+            Self {
+                input,
+                operator_pubkey,
+                amount,
+                disprove_scripts,
+                payout_script,
+                __program: PhantomData,
+            },
+            idx,
+        )
     }
 
     /// Return partially signed transaction with P2TR output with all disprove

--- a/core/src/assert/payout_script.rs
+++ b/core/src/assert/payout_script.rs
@@ -1,0 +1,56 @@
+use bitcoin::{
+    hashes::{hash160::Hash as Hash160, Hash},
+    relative::Height,
+    XOnlyPublicKey,
+};
+
+use crate::treepp::*;
+
+/// Assuming that mean block mining time is 10 minutes:
+pub const LOCKTIME: u16 =  6 /* hour */ * 24 /* day */ * 14 /* two weeks */;
+
+/// Script by which Operator spends the Assert transaction after timelock.
+#[derive(Debug, Clone)]
+pub struct PayoutScript {
+    // TODO(Velnbur): add mutisig of the comittee.
+    // pub comittee_pubkeys: Vec<PublicKey>,
+    /// Public key of the operator
+    pub operator_pubkey: XOnlyPublicKey,
+
+    /// Specified locktime after which assert transaction is spendable
+    /// by payout script, default value is [`LOCKTIME`].
+    pub locktime: Height,
+}
+
+impl PayoutScript {
+    pub fn new(operator_pubkey: XOnlyPublicKey) -> Self {
+        Self {
+            operator_pubkey,
+            locktime: Height::from(LOCKTIME),
+        }
+    }
+
+    pub fn with_locktime(operator_pubkey: XOnlyPublicKey, locktime: Height) -> Self {
+        Self {
+            operator_pubkey,
+            locktime,
+        }
+    }
+
+    pub fn to_script(&self) -> Script {
+        script! {
+            { self.locktime.value() as u32 }
+            OP_CSV
+            OP_DROP
+            OP_DUP
+            OP_HASH160
+            {
+                Hash160::hash(
+                    &self.operator_pubkey.serialize()
+                ).as_byte_array().to_vec()
+            }
+            OP_EQUALVERIFY
+            OP_CHECKSIG
+        }
+    }
+}

--- a/core/src/disprove/mod.rs
+++ b/core/src/disprove/mod.rs
@@ -122,8 +122,9 @@ impl DisproveScript {
                 }
                 Instruction::Op(opcode) => {
                     match opcode.classify(ClassifyContext::TapScript) {
-                        bitcoin::opcodes::Class::PushNum(_) => {
-                            elements.push([opcode.to_u8()].to_vec());
+                        bitcoin::opcodes::Class::PushNum(num) => {
+                            let buf = num.to_le_bytes().into_iter().filter(|b| *b != 0).collect();
+                            elements.push(buf);
                         }
                         _ => {
                             unreachable!("script witness shouldn't have opcodes, got {opcode}")

--- a/core/src/disprove/tests.rs
+++ b/core/src/disprove/tests.rs
@@ -2,7 +2,10 @@ use std::{fs, path::Path, str::FromStr as _};
 
 use crate::disprove::{form_disprove_scripts_distorted, DisproveScript};
 
-use bitcoin::{consensus::Encodable as _, hashes::Hash as _, key::Secp256k1, secp256k1::SecretKey, Amount, OutPoint, TxOut, WPubkeyHash};
+use bitcoin::{
+    consensus::Encodable as _, hashes::Hash as _, key::Secp256k1, secp256k1::SecretKey, Amount,
+    OutPoint, TxOut, WPubkeyHash,
+};
 use bitcoin_splitter::split::{
     core::SplitType,
     intermediate_state::IntermediateState,

--- a/core/src/disprove/tests.rs
+++ b/core/src/disprove/tests.rs
@@ -1,5 +1,8 @@
+use std::{fs, path::Path, str::FromStr as _};
+
 use crate::disprove::{form_disprove_scripts_distorted, DisproveScript};
 
+use bitcoin::{consensus::Encodable as _, hashes::Hash as _, key::Secp256k1, secp256k1::SecretKey, Amount, OutPoint, TxOut, WPubkeyHash};
 use bitcoin_splitter::split::{
     core::SplitType,
     intermediate_state::IntermediateState,
@@ -13,8 +16,12 @@ use bitcoin_testscripts::{
 use bitcoin_utils::stack_to_script;
 use bitcoin_utils::{comparison::OP_LONGEQUALVERIFY, treepp::*};
 use bitcoin_window_mul::{bigint::U508, traits::comparable::Comparable};
+use once_cell::sync::Lazy;
 
-use super::{form_disprove_scripts, signing::SignedIntermediateState};
+use crate::{
+    assert::AssertTransaction, disprove::form_disprove_scripts,
+    disprove::signing::SignedIntermediateState,
+};
 
 #[test]
 pub fn test_stack_sign_and_verify() {
@@ -485,4 +492,88 @@ pub fn test_disprove_script_batch_correctness() {
         let result = execute_script(verify_script);
         assert!(!result.success, "Verification {:?} failed", i + 1);
     }
+}
+
+static SECKEY: Lazy<SecretKey> = Lazy::new(|| {
+    "50c8f972285ad27527d79c80fe4df1b63c1192047713438b45758ea4e110a88b"
+        .parse()
+        .unwrap()
+});
+
+#[test]
+fn test_assert_tx_signing() {
+    let IOPair { input, .. } = U254MulScript::generate_invalid_io_pair();
+
+    let ctx = Secp256k1::new();
+
+    let operator_pubkey = SECKEY.public_key(&ctx);
+    let operator_xonly = operator_pubkey.x_only_public_key().0;
+
+    let assert_tx = AssertTransaction::<
+        { U254MulScript::INPUT_SIZE },
+        { U254MulScript::OUTPUT_SIZE },
+        U254MulScript,
+    >::new(input, operator_xonly, Amount::from_sat(70_000));
+
+    let operator_script_pubkey =
+        Script::new_p2wpkh(&WPubkeyHash::hash(&operator_pubkey.serialize()));
+
+    let utxo = TxOut {
+        value: Amount::from_sat(73_000),
+        script_pubkey: operator_script_pubkey.clone(),
+    };
+
+    let outpoint =
+        OutPoint::from_str("a85d89b4666fed622281d3589474aa1f87971b54bd5d9c1899ed2e8e0447cc06:0")
+            .unwrap();
+
+    let tx = assert_tx
+        .clone()
+        .spend_p2wpkh_input_tx(&ctx, &SECKEY, utxo, outpoint)
+        .unwrap();
+
+    let txid = tx.compute_txid();
+    println!("Assert:");
+    dump_hex_tx_to_file(tx, "assert.hex");
+
+    let payout = assert_tx
+        .clone()
+        .payout_transaction(
+            &ctx,
+            TxOut {
+                value: Amount::from_sat(69_000),
+                script_pubkey: operator_script_pubkey.clone(),
+            },
+            txid,
+            &SECKEY,
+        )
+        .unwrap();
+    println!("Payout:");
+    dump_hex_tx_to_file(payout, "payout.hex");
+
+    let disprove_txs = assert_tx
+        .clone()
+        .disprove_transactions(
+            &ctx,
+            TxOut {
+                value: Amount::from_sat(69_000),
+                script_pubkey: operator_script_pubkey,
+            },
+            txid,
+        )
+        .unwrap();
+
+    println!("Number of disprove scripts: {}", disprove_txs.len());
+    for (idx, (_script, tx)) in disprove_txs.into_iter().enumerate() {
+        println!("Disprove{idx}:");
+        dump_hex_tx_to_file(tx, format!("disprove_{}.hex", idx));
+    }
+}
+
+fn dump_hex_tx_to_file(tx: bitcoin::Transaction, path: impl AsRef<Path>) {
+    let mut buf = Vec::new();
+    tx.consensus_encode(&mut buf).unwrap();
+    println!("Length: {}", buf.len());
+    let encoded = hex::encode(&buf);
+    fs::write(path, encoded).unwrap();
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,12 +3,11 @@ use once_cell::sync::Lazy;
 pub mod assert;
 pub mod disprove;
 
-
 #[allow(dead_code)]
 // Re-export what is needed to write treepp scripts
 pub mod treepp {
-    pub use bitcoin_utils::debug::{execute_script, run};
     pub use bitcoin_script::{define_pushable, script};
+    pub use bitcoin_utils::debug::{execute_script, run};
 
     define_pushable!();
     pub use bitcoin::ScriptBuf as Script;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,2 +1,33 @@
+use bitcoin::XOnlyPublicKey;
+use once_cell::sync::Lazy;
 pub mod assert;
 pub mod disprove;
+
+
+#[allow(dead_code)]
+// Re-export what is needed to write treepp scripts
+pub mod treepp {
+    pub use bitcoin_utils::debug::{execute_script, run};
+    pub use bitcoin_script::{define_pushable, script};
+
+    define_pushable!();
+    pub use bitcoin::ScriptBuf as Script;
+}
+
+// FIXME(Velnbur): Use really non spendable key. For example checkout:
+// 1. https://github.com/nomic-io/nomic/blob/5ba8b661e6d9ffb6b9eb39c13247cccefa5342a9/src/babylon/mod.rs#L451
+pub static UNSPENDABLE_KEY: Lazy<XOnlyPublicKey> = Lazy::new(|| {
+    "1e37ec522cb319c66e1a21077a2ba05c070efa5c018d5bc8d002250f5ca0c7dc"
+        .parse()
+        .unwrap()
+});
+
+#[cfg(test)]
+mod tests {
+    use crate::UNSPENDABLE_KEY;
+
+    #[test]
+    fn test_unspendable_key() {
+        let _ = *UNSPENDABLE_KEY;
+    }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       interval: 2s
     volumes:
       - ./configs/bitcoind.conf:/root/.bitcoin/bitcoin.conf
-      - ./local-volumes/bitcoind:/root/.bitcoin
+      - bitcoind:/root/.bitcoin
     entrypoint:
       - "sh"
       - "-c"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -14,3 +14,8 @@ serde_json = "1.0.128"
 serde = "1.0.194"
 tracing.workspace = true
 tracing-subscriber.workspace = true
+hex = "0.4.3"
+
+bitvm2-core.path = "../core"
+bitcoin-splitter.path = "../bitcoin-splitter"
+bitcoin-testscripts.path = "../bitcoin-testscripts"

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -3,3 +3,6 @@ mod common;
 
 #[cfg(test)]
 mod fetch_balance;
+
+#[cfg(test)]
+mod taproot;

--- a/integration-tests/src/taproot.rs
+++ b/integration-tests/src/taproot.rs
@@ -10,7 +10,7 @@ use bitcoin::{
 };
 use bitcoin_splitter::split::script::{IOPair, SplitableScript};
 use bitcoin_testscripts::{
-    int_mul_windowed::U254MulScript, square_fibonacci::SquareFibonacciScript, u29mul::U29MulScript,
+    int_mul_windowed::U254MulScript, square_fibonacci::SquareFibonacciScript, u32mul::U32MulScript,
 };
 use bitcoincore_rpc::{
     bitcoin::consensus::{Decodable as _, Encodable as _},
@@ -285,10 +285,10 @@ fn test_square_fibonachi_disprove() -> eyre::Result<()> {
 }
 
 #[test]
-fn test_u29mul_disprove() -> eyre::Result<()> {
+fn test_u32mul_disprove() -> eyre::Result<()> {
     test_script_disprove_distorted::<
-        { U29MulScript::INPUT_SIZE },
-        { U29MulScript::OUTPUT_SIZE },
-        U29MulScript,
+        { U32MulScript::INPUT_SIZE },
+        { U32MulScript::OUTPUT_SIZE },
+        U32MulScript,
     >()
 }

--- a/integration-tests/src/taproot.rs
+++ b/integration-tests/src/taproot.rs
@@ -231,21 +231,23 @@ where
         atx.compute_txid(),
     )?;
 
-    tracing::info!("Number of disprove txs: {}", disprove_txs.len());
+    let number = disprove_txs.len();
+    tracing::info!("Number of disprove txs: {}", number);
     for (idx, (_disprove_script, disprove_tx)) in disprove_txs.into_iter().enumerate() {
         let err = client.send_raw_transaction(txconv!(disprove_tx)).err();
 
-        let hexed = hex!(disprove_tx);
-        println!("Txid: {}", disprove_tx.compute_txid());
-        println!("DisproveSize: {}", hexed.len() / 2); // as it's hex
-        // println!("DisproveScript: {}", disprove_script);
-        println!("DisproveTx: {}", hexed);
-        // fs::write("./disprove.hex", hexed)?;
-
         if let Some(err) = err {
-            tracing::error!(reason = %err, "Disprove Tx {idx} rejected...");
+            tracing::warn!(reason = %err, "Disprove Tx {idx} rejected...");
+            if idx + 1 == number {
+                panic!("no dispove transaction worked!");
+            }
             continue;
         }
+
+        let hexed = hex!(disprove_tx);
+        println!("Txid: {}", disprove_tx.compute_txid());
+        println!("DisproveSize: {}", hexed.len() / 2);
+        fs::write("./disprove.hex", hexed)?;
         break;
     }
 
@@ -276,9 +278,9 @@ fn test_u254_mul_payout() -> eyre::Result<()> {
 #[test]
 fn test_square_fibonachi_disprove() -> eyre::Result<()> {
     test_script_disprove_distorted::<
-        { SquareFibonacciScript::<5>::INPUT_SIZE },
-        { SquareFibonacciScript::<5>::OUTPUT_SIZE },
-        SquareFibonacciScript<5>,
+        { SquareFibonacciScript::<1024>::INPUT_SIZE },
+        { SquareFibonacciScript::<1024>::OUTPUT_SIZE },
+        SquareFibonacciScript<1024>,
     >()
 }
 

--- a/integration-tests/src/taproot.rs
+++ b/integration-tests/src/taproot.rs
@@ -1,0 +1,144 @@
+use std::str::FromStr as _;
+
+use bitcoin::{
+    consensus::{Decodable, Encodable as _},
+    io::Cursor,
+    key::Secp256k1,
+    relative::Height,
+    secp256k1::SecretKey,
+    Address, Amount, CompressedPublicKey, Network, OutPoint, Transaction, TxOut,
+};
+use bitcoin_splitter::split::script::{IOPair, SplitableScript as _};
+use bitcoin_testscripts::int_mul_windowed::U254MulScript;
+use bitcoincore_rpc::{
+    bitcoin::consensus::{Decodable as _, Encodable as _},
+    RawTx as _, RpcApi,
+};
+use bitvm2_core::assert::{AssertTransaction, Options};
+// use bitcoin_splitter::treepp::*;
+use once_cell::sync::Lazy;
+
+use crate::common::{init_bitcoin_client, init_wallet};
+
+static SECKEY: Lazy<SecretKey> = Lazy::new(|| {
+    "50c8f972285ad27527d79c80fe4df1b63c1192047713438b45758ea4e110a88b"
+        .parse()
+        .unwrap()
+});
+
+macro_rules! hex {
+    ($tx:expr) => {{
+        let mut buf = Vec::new();
+        $tx.consensus_encode(&mut buf).unwrap();
+        hex::encode(&buf)
+    }};
+}
+
+#[test]
+fn test_simple_singature_script() -> eyre::Result<()> {
+    color_eyre::install()?;
+    tracing_subscriber::fmt().init();
+
+    let client = init_bitcoin_client()?;
+
+    let address = init_wallet()?;
+
+    let IOPair { input, .. } = U254MulScript::generate_invalid_io_pair();
+
+    let ctx = Secp256k1::new();
+
+    let operator_pubkey = SECKEY.public_key(&ctx);
+    let operator_xonly = operator_pubkey.x_only_public_key().0;
+
+    let operator_p2wpkh_addr = Address::p2wpkh(
+        &CompressedPublicKey::try_from(bitcoin::PublicKey::new(operator_pubkey)).unwrap(),
+        Network::Regtest,
+    );
+
+    // TODO(Velnbur): fix version of bitcoincorerpc and Bitcoin for this...
+    let operator_funding_txid = client.send_to_address(
+        &bitcoincore_rpc::bitcoin::Address::from_str(&operator_p2wpkh_addr.to_string())
+            .unwrap()
+            .assume_checked(),
+        bitcoincore_rpc::bitcoin::Amount::from_sat(71_000),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )?;
+    let tx = client.get_raw_transaction(&operator_funding_txid, None)?;
+    let tx = {
+        let mut buf = Vec::new();
+        tx.consensus_encode(&mut buf).unwrap();
+        let mut cursor = Cursor::new(&buf);
+        Transaction::consensus_decode(&mut cursor)?
+    };
+
+    println!("Txid: {}", operator_funding_txid);
+    println!("Funding: {}", hex!(tx));
+    client.generate_to_address(6, &address)?;
+
+    // find txout
+    let txid = tx.compute_txid();
+    let (idx, funding_txout) = tx
+        .output
+        .into_iter()
+        .enumerate()
+        .find(|(_idx, out)| out.value == Amount::from_sat(71_000))
+        .unwrap();
+
+    let assert_tx = AssertTransaction::<
+        { U254MulScript::INPUT_SIZE },
+        { U254MulScript::OUTPUT_SIZE },
+        U254MulScript,
+    >::with_options(
+        input,
+        operator_xonly,
+        Amount::from_sat(70_000),
+        Options {
+            payout_locktime: Height::from(1),
+        },
+    );
+
+    let atx = assert_tx.clone().spend_p2wpkh_input_tx(
+        &ctx,
+        &SECKEY,
+        funding_txout.clone(),
+        OutPoint::new(txid, idx as u32),
+    )?;
+
+    println!("Txid: {}", atx.compute_txid());
+    // println!("AssertSize: {}", hex!(atx).len());
+    println!("Assert: {}", hex!(atx));
+    client.send_raw_transaction({
+        let mut buf = Vec::new();
+        atx.consensus_encode(&mut buf).unwrap();
+        let mut cursor = std::io::Cursor::new(&buf);
+        bitcoincore_rpc::bitcoin::Transaction::consensus_decode(&mut cursor)?.raw_hex()
+    })?;
+    client.generate_to_address(1, &address)?;
+
+    let payout_tx = assert_tx.payout_transaction(
+        &ctx,
+        TxOut {
+            value: Amount::from_sat(69_000),
+            script_pubkey: funding_txout.script_pubkey,
+        },
+        atx.compute_txid(),
+        &SECKEY,
+    )?;
+
+    println!("Txid: {}", payout_tx.compute_txid());
+    println!("Payout: {}", hex!(payout_tx));
+    client.send_raw_transaction({
+        let mut buf = Vec::new();
+        payout_tx.consensus_encode(&mut buf).unwrap();
+        let mut cursor = std::io::Cursor::new(&buf);
+        bitcoincore_rpc::bitcoin::Transaction::consensus_decode(&mut cursor)?.raw_hex()
+    })?;
+    client.generate_to_address(6, &address)?;
+
+    Ok(())
+}

--- a/integration-tests/src/taproot.rs
+++ b/integration-tests/src/taproot.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr as _;
+use std::{fs, str::FromStr as _};
 
 use bitcoin::{
     consensus::{Decodable, Encodable as _},
@@ -8,15 +8,17 @@ use bitcoin::{
     secp256k1::SecretKey,
     Address, Amount, CompressedPublicKey, Network, OutPoint, Transaction, TxOut,
 };
-use bitcoin_splitter::split::script::{IOPair, SplitableScript as _};
-use bitcoin_testscripts::int_mul_windowed::U254MulScript;
+use bitcoin_splitter::split::script::{IOPair, SplitableScript};
+use bitcoin_testscripts::{
+    int_mul_windowed::U254MulScript, square_fibonacci::SquareFibonacciScript,
+};
 use bitcoincore_rpc::{
     bitcoin::consensus::{Decodable as _, Encodable as _},
     RawTx as _, RpcApi,
 };
 use bitvm2_core::assert::{AssertTransaction, Options};
-// use bitcoin_splitter::treepp::*;
 use once_cell::sync::Lazy;
+use tracing_subscriber::fmt::format;
 
 use crate::common::{init_bitcoin_client, init_wallet};
 
@@ -34,8 +36,19 @@ macro_rules! hex {
     }};
 }
 
-#[test]
-fn test_simple_singature_script() -> eyre::Result<()> {
+macro_rules! txconv {
+    ($tx:expr) => {{
+        let mut buf = Vec::new();
+        $tx.consensus_encode(&mut buf).unwrap();
+        let mut cursor = std::io::Cursor::new(&buf);
+        bitcoincore_rpc::bitcoin::Transaction::consensus_decode(&mut cursor)?.raw_hex()
+    }};
+}
+
+fn test_script_payout_spending<const I: usize, const O: usize, S>() -> eyre::Result<()>
+where
+    S: SplitableScript<I, O>,
+{
     color_eyre::install()?;
     tracing_subscriber::fmt().init();
 
@@ -43,7 +56,7 @@ fn test_simple_singature_script() -> eyre::Result<()> {
 
     let address = init_wallet()?;
 
-    let IOPair { input, .. } = U254MulScript::generate_invalid_io_pair();
+    let IOPair { input, .. } = S::generate_invalid_io_pair();
 
     let ctx = Secp256k1::new();
 
@@ -89,11 +102,7 @@ fn test_simple_singature_script() -> eyre::Result<()> {
         .find(|(_idx, out)| out.value == Amount::from_sat(71_000))
         .unwrap();
 
-    let assert_tx = AssertTransaction::<
-        { U254MulScript::INPUT_SIZE },
-        { U254MulScript::OUTPUT_SIZE },
-        U254MulScript,
-    >::with_options(
+    let assert_tx = AssertTransaction::<{ I }, { O }, S>::with_options(
         input,
         operator_xonly,
         Amount::from_sat(70_000),
@@ -112,12 +121,7 @@ fn test_simple_singature_script() -> eyre::Result<()> {
     println!("Txid: {}", atx.compute_txid());
     // println!("AssertSize: {}", hex!(atx).len());
     println!("Assert: {}", hex!(atx));
-    client.send_raw_transaction({
-        let mut buf = Vec::new();
-        atx.consensus_encode(&mut buf).unwrap();
-        let mut cursor = std::io::Cursor::new(&buf);
-        bitcoincore_rpc::bitcoin::Transaction::consensus_decode(&mut cursor)?.raw_hex()
-    })?;
+    client.send_raw_transaction(txconv!(atx))?;
     client.generate_to_address(1, &address)?;
 
     let payout_tx = assert_tx.payout_transaction(
@@ -132,13 +136,146 @@ fn test_simple_singature_script() -> eyre::Result<()> {
 
     println!("Txid: {}", payout_tx.compute_txid());
     println!("Payout: {}", hex!(payout_tx));
-    client.send_raw_transaction({
-        let mut buf = Vec::new();
-        payout_tx.consensus_encode(&mut buf).unwrap();
-        let mut cursor = std::io::Cursor::new(&buf);
-        bitcoincore_rpc::bitcoin::Transaction::consensus_decode(&mut cursor)?.raw_hex()
-    })?;
+    client.send_raw_transaction(txconv!(payout_tx))?;
     client.generate_to_address(6, &address)?;
 
     Ok(())
+}
+
+fn test_script_disprove_distorted<const I: usize, const O: usize, S>() -> eyre::Result<()>
+where
+    S: SplitableScript<I, O>,
+{
+    color_eyre::install()?;
+    let format = format().pretty();
+    tracing_subscriber::fmt().event_format(format).init();
+
+    let client = init_bitcoin_client()?;
+
+    let address = init_wallet()?;
+
+    let IOPair { input, .. } = S::generate_invalid_io_pair();
+
+    let ctx = Secp256k1::new();
+
+    let operator_pubkey = SECKEY.public_key(&ctx);
+    let operator_xonly = operator_pubkey.x_only_public_key().0;
+
+    let operator_p2wpkh_addr = Address::p2wpkh(
+        &CompressedPublicKey::try_from(bitcoin::PublicKey::new(operator_pubkey)).unwrap(),
+        Network::Regtest,
+    );
+
+    // TODO(Velnbur): fix version of bitcoincorerpc and Bitcoin for this...
+    let operator_funding_txid = client.send_to_address(
+        &bitcoincore_rpc::bitcoin::Address::from_str(&operator_p2wpkh_addr.to_string())
+            .unwrap()
+            .assume_checked(),
+        bitcoincore_rpc::bitcoin::Amount::from_sat(100_000),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )?;
+    let tx = client.get_raw_transaction(&operator_funding_txid, None)?;
+    let tx = {
+        let mut buf = Vec::new();
+        tx.consensus_encode(&mut buf).unwrap();
+        let mut cursor = Cursor::new(&buf);
+        Transaction::consensus_decode(&mut cursor)?
+    };
+
+    println!("Txid: {}", operator_funding_txid);
+    println!("Funding: {}", hex!(tx));
+    client.generate_to_address(6, &address)?;
+
+    // find txout
+    let txid = tx.compute_txid();
+    let (idx, funding_txout) = tx
+        .output
+        .into_iter()
+        .enumerate()
+        .find(|(_idx, out)| out.value == Amount::from_sat(100_000))
+        .unwrap();
+
+    let (assert_tx, _distored_idx) = AssertTransaction::<{ I }, { O }, S>::with_options_distorted(
+        input,
+        operator_xonly,
+        Amount::from_sat(99_000),
+        Options {
+            payout_locktime: Height::from(1),
+        },
+    );
+
+    let atx = assert_tx.clone().spend_p2wpkh_input_tx(
+        &ctx,
+        &SECKEY,
+        funding_txout.clone(),
+        OutPoint::new(txid, idx as u32),
+    )?;
+
+    println!("Txid: {}", atx.compute_txid());
+    // println!("AssertSize: {}", hex!(atx).len());
+    println!("Assert: {}", hex!(atx));
+    client.send_raw_transaction(txconv!(atx))?;
+    client.generate_to_address(1, &address)?;
+
+    let disprove_txs = assert_tx.clone().disprove_transactions(
+        &ctx,
+        TxOut {
+            value: Amount::from_sat(9_000),
+            script_pubkey: funding_txout.script_pubkey,
+        },
+        atx.compute_txid(),
+    )?;
+
+    tracing::info!("Number of disprove txs: {}", disprove_txs.len());
+    for (idx, (_, disprove_tx)) in disprove_txs.into_iter().enumerate() {
+        let err = client.send_raw_transaction(txconv!(disprove_tx)).err();
+
+        if let Some(err) = err {
+            tracing::error!(reason = %err, "Disprove Tx {idx} rejected...");
+            continue;
+        }
+        
+        let hexed = hex!(disprove_tx);
+        println!("Txid: {}", disprove_tx.compute_txid());
+        println!("DisproveSize: {}", hexed.len() / 2); // as it's hex
+        fs::write("./disprove.hex", hexed)?;
+        break;
+    }
+
+    client.generate_to_address(6, &address)?;
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "Stack size limit exceeded"]
+fn test_u254_mul_disprove() -> eyre::Result<()> {
+    test_script_disprove_distorted::<
+        { U254MulScript::INPUT_SIZE },
+        { U254MulScript::OUTPUT_SIZE },
+        U254MulScript,
+    >()
+}
+
+#[test]
+fn test_u254_mul_payout() -> eyre::Result<()> {
+    test_script_payout_spending::<
+        { U254MulScript::INPUT_SIZE },
+        { U254MulScript::OUTPUT_SIZE },
+        U254MulScript,
+    >()
+}
+
+#[test]
+fn test_square_fibonachi_disprove() -> eyre::Result<()> {
+    test_script_disprove_distorted::<
+        { SquareFibonacciScript::<5>::INPUT_SIZE },
+        { SquareFibonacciScript::<5>::OUTPUT_SIZE },
+        SquareFibonacciScript<5>,
+    >()
 }

--- a/integration-tests/src/taproot.rs
+++ b/integration-tests/src/taproot.rs
@@ -279,7 +279,6 @@ fn test_square_fibonachi() -> eyre::Result<()> {
 }
 
 #[test]
-#[ignore = "Stack size limit exceeded"]
 fn test_u32mul_disprove() -> eyre::Result<()> {
     color_eyre::install()?;
     tracing_subscriber::fmt().init();

--- a/integration-tests/src/taproot.rs
+++ b/integration-tests/src/taproot.rs
@@ -1,12 +1,12 @@
-use std::{fs, str::FromStr as _};
+use std::{env, fs, str::FromStr as _};
 
 use bitcoin::{
     consensus::{Decodable, Encodable as _},
     io::Cursor,
     key::Secp256k1,
     relative::Height,
-    secp256k1::SecretKey,
-    Address, Amount, CompressedPublicKey, Network, OutPoint, Transaction, TxOut,
+    secp256k1::{All, PublicKey, SecretKey},
+    Address, Amount, CompressedPublicKey, Network, OutPoint, Transaction, TxOut, Txid,
 };
 use bitcoin_splitter::split::script::{IOPair, SplitableScript};
 use bitcoin_testscripts::{
@@ -16,16 +16,23 @@ use bitcoincore_rpc::{
     bitcoin::consensus::{Decodable as _, Encodable as _},
     RawTx as _, RpcApi,
 };
-use bitvm2_core::assert::{AssertTransaction, Options};
+use bitvm2_core::{
+    assert::{AssertTransaction, Options},
+    treepp::*,
+};
 use once_cell::sync::Lazy;
-use tracing_subscriber::fmt::format;
 
 use crate::common::{init_bitcoin_client, init_wallet};
 
-static SECKEY: Lazy<SecretKey> = Lazy::new(|| {
+static OPERATOR_SECKEY: Lazy<SecretKey> = Lazy::new(|| {
     "50c8f972285ad27527d79c80fe4df1b63c1192047713438b45758ea4e110a88b"
         .parse()
         .unwrap()
+});
+
+static OPERATOR_PUBKEY: Lazy<PublicKey> = Lazy::new(|| {
+    let ctx = Secp256k1::new();
+    OPERATOR_SECKEY.public_key(&ctx)
 });
 
 macro_rules! hex {
@@ -45,24 +52,29 @@ macro_rules! txconv {
     }};
 }
 
-fn test_script_payout_spending<const I: usize, const O: usize, S>() -> eyre::Result<()>
+struct TestSetup {
+    ctx: Secp256k1<All>,
+    client: bitcoincore_rpc::Client,
+    funder_address: bitcoincore_rpc::bitcoin::Address,
+    input_script: Script,
+    _output_script: Script,
+    funding_txid: Txid,
+    funding_txout_idx: usize,
+    funding_txout: TxOut,
+}
+
+fn setup_test<const I: usize, const O: usize, S>(amount_sats: u64) -> eyre::Result<TestSetup>
 where
     S: SplitableScript<I, O>,
 {
-    color_eyre::install()?;
-    tracing_subscriber::fmt().init();
-
     let client = init_bitcoin_client()?;
-
     let address = init_wallet()?;
 
-    let IOPair { input, .. } = S::generate_invalid_io_pair();
+    let IOPair { input, output } = S::generate_invalid_io_pair();
 
     let ctx = Secp256k1::new();
 
-    let operator_pubkey = SECKEY.public_key(&ctx);
-    let operator_xonly = operator_pubkey.x_only_public_key().0;
-
+    let operator_pubkey = OPERATOR_SECKEY.public_key(&ctx);
     let operator_p2wpkh_addr = Address::p2wpkh(
         &CompressedPublicKey::try_from(bitcoin::PublicKey::new(operator_pubkey)).unwrap(),
         Network::Regtest,
@@ -73,7 +85,7 @@ where
         &bitcoincore_rpc::bitcoin::Address::from_str(&operator_p2wpkh_addr.to_string())
             .unwrap()
             .assume_checked(),
-        bitcoincore_rpc::bitcoin::Amount::from_sat(71_000),
+        bitcoincore_rpc::bitcoin::Amount::from_sat(amount_sats),
         None,
         None,
         None,
@@ -89,8 +101,7 @@ where
         Transaction::consensus_decode(&mut cursor)?
     };
 
-    println!("Txid: {}", operator_funding_txid);
-    println!("Funding: {}", hex!(tx));
+    tracing::info!(hex = %hex!(tx), txid = %operator_funding_txid, "Created funding");
     client.generate_to_address(6, &address)?;
 
     // find txout
@@ -99,11 +110,39 @@ where
         .output
         .into_iter()
         .enumerate()
-        .find(|(_idx, out)| out.value == Amount::from_sat(71_000))
+        .find(|(_idx, out)| out.value == Amount::from_sat(amount_sats))
         .unwrap();
 
+    Ok(TestSetup {
+        ctx,
+        client,
+        funder_address: address,
+        input_script: input,
+        _output_script: output,
+        funding_txid: txid,
+        funding_txout_idx: idx,
+        funding_txout,
+    })
+}
+
+fn test_script_payout_spending<const I: usize, const O: usize, S>() -> eyre::Result<()>
+where
+    S: SplitableScript<I, O>,
+{
+    let TestSetup {
+        ctx,
+        client,
+        input_script,
+        funding_txid,
+        funding_txout_idx,
+        funding_txout,
+        funder_address,
+        ..
+    } = setup_test::<I, O, S>(71_000)?;
+
+    let operator_xonly = OPERATOR_PUBKEY.x_only_public_key().0;
     let assert_tx = AssertTransaction::<{ I }, { O }, S>::with_options(
-        input,
+        input_script,
         operator_xonly,
         Amount::from_sat(70_000),
         Options {
@@ -113,16 +152,15 @@ where
 
     let atx = assert_tx.clone().spend_p2wpkh_input_tx(
         &ctx,
-        &SECKEY,
+        &OPERATOR_SECKEY,
         funding_txout.clone(),
-        OutPoint::new(txid, idx as u32),
+        OutPoint::new(funding_txid, funding_txout_idx as u32),
     )?;
 
     println!("Txid: {}", atx.compute_txid());
-    // println!("AssertSize: {}", hex!(atx).len());
     println!("Assert: {}", hex!(atx));
     client.send_raw_transaction(txconv!(atx))?;
-    client.generate_to_address(1, &address)?;
+    client.generate_to_address(1, &funder_address)?;
 
     let payout_tx = assert_tx.payout_transaction(
         &ctx,
@@ -131,13 +169,13 @@ where
             script_pubkey: funding_txout.script_pubkey,
         },
         atx.compute_txid(),
-        &SECKEY,
+        &OPERATOR_SECKEY,
     )?;
 
     println!("Txid: {}", payout_tx.compute_txid());
     println!("Payout: {}", hex!(payout_tx));
     client.send_raw_transaction(txconv!(payout_tx))?;
-    client.generate_to_address(6, &address)?;
+    client.generate_to_address(6, &funder_address)?;
 
     Ok(())
 }
@@ -146,64 +184,22 @@ fn test_script_disprove_distorted<const I: usize, const O: usize, S>() -> eyre::
 where
     S: SplitableScript<I, O>,
 {
-    color_eyre::install()?;
-    let format = format().pretty();
-    tracing_subscriber::fmt().event_format(format).init();
+    let TestSetup {
+        ctx,
+        client,
+        input_script,
+        funding_txid,
+        funding_txout_idx,
+        funding_txout,
+        funder_address,
+        ..
+    } = setup_test::<I, O, S>(100_000)?;
 
-    let client = init_bitcoin_client()?;
-
-    let address = init_wallet()?;
-
-    let IOPair { input, .. } = S::generate_invalid_io_pair();
-
-    let ctx = Secp256k1::new();
-
-    let operator_pubkey = SECKEY.public_key(&ctx);
-    let operator_xonly = operator_pubkey.x_only_public_key().0;
-
-    let operator_p2wpkh_addr = Address::p2wpkh(
-        &CompressedPublicKey::try_from(bitcoin::PublicKey::new(operator_pubkey)).unwrap(),
-        Network::Regtest,
-    );
-
-    // TODO(Velnbur): fix version of bitcoincorerpc and Bitcoin for this...
-    let operator_funding_txid = client.send_to_address(
-        &bitcoincore_rpc::bitcoin::Address::from_str(&operator_p2wpkh_addr.to_string())
-            .unwrap()
-            .assume_checked(),
-        bitcoincore_rpc::bitcoin::Amount::from_sat(100_000),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    )?;
-    let tx = client.get_raw_transaction(&operator_funding_txid, None)?;
-    let tx = {
-        let mut buf = Vec::new();
-        tx.consensus_encode(&mut buf).unwrap();
-        let mut cursor = Cursor::new(&buf);
-        Transaction::consensus_decode(&mut cursor)?
-    };
-
-    println!("Txid: {}", operator_funding_txid);
-    println!("Funding: {}", hex!(tx));
-    client.generate_to_address(6, &address)?;
-
-    // find txout
-    let txid = tx.compute_txid();
-    let (idx, funding_txout) = tx
-        .output
-        .into_iter()
-        .enumerate()
-        .find(|(_idx, out)| out.value == Amount::from_sat(100_000))
-        .unwrap();
-
-    let (assert_tx, _distored_idx) = AssertTransaction::<{ I }, { O }, S>::with_options_distorted(
-        input,
+    let operator_xonly = OPERATOR_PUBKEY.x_only_public_key().0;
+    let (assert_tx, distored_idx) = AssertTransaction::<{ I }, { O }, S>::with_options_distorted(
+        input_script,
         operator_xonly,
-        Amount::from_sat(99_000),
+        Amount::from_sat(90_000),
         Options {
             payout_locktime: Height::from(1),
         },
@@ -211,16 +207,15 @@ where
 
     let atx = assert_tx.clone().spend_p2wpkh_input_tx(
         &ctx,
-        &SECKEY,
+        &OPERATOR_SECKEY,
         funding_txout.clone(),
-        OutPoint::new(txid, idx as u32),
+        OutPoint::new(funding_txid, funding_txout_idx as u32),
     )?;
 
     println!("Txid: {}", atx.compute_txid());
-    // println!("AssertSize: {}", hex!(atx).len());
     println!("Assert: {}", hex!(atx));
     client.send_raw_transaction(txconv!(atx))?;
-    client.generate_to_address(1, &address)?;
+    client.generate_to_address(1, &funder_address)?;
 
     let disprove_txs = assert_tx.clone().disprove_transactions(
         &ctx,
@@ -231,27 +226,20 @@ where
         atx.compute_txid(),
     )?;
 
-    let number = disprove_txs.len();
-    tracing::info!("Number of disprove txs: {}", number);
-    for (idx, (_disprove_script, disprove_tx)) in disprove_txs.into_iter().enumerate() {
-        let err = client.send_raw_transaction(txconv!(disprove_tx)).err();
+    let disprove_tx = disprove_txs
+        .get(&assert_tx.disprove_scripts[distored_idx])
+        .unwrap();
+    client.send_raw_transaction(txconv!(disprove_tx))?;
 
-        if let Some(err) = err {
-            tracing::warn!(reason = %err, "Disprove Tx {idx} rejected...");
-            if idx + 1 == number {
-                panic!("no dispove transaction worked!");
-            }
-            continue;
-        }
+    let hexed = hex!(disprove_tx);
+    println!("Txid: {}", disprove_tx.compute_txid());
+    println!("DisproveSize: {}", hexed.len() / 2);
 
-        let hexed = hex!(disprove_tx);
-        println!("Txid: {}", disprove_tx.compute_txid());
-        println!("DisproveSize: {}", hexed.len() / 2);
-        fs::write("./disprove.hex", hexed)?;
-        break;
+    if env::var("NERO_TESTS_TX_FILE").is_ok() {
+        fs::write("./disprove.txt", hexed)?;
     }
 
-    client.generate_to_address(6, &address)?;
+    client.generate_to_address(6, &funder_address)?;
 
     Ok(())
 }
@@ -259,6 +247,8 @@ where
 #[test]
 #[ignore = "Stack size limit exceeded"]
 fn test_u254_mul_disprove() -> eyre::Result<()> {
+    color_eyre::install()?;
+    tracing_subscriber::fmt().init();
     test_script_disprove_distorted::<
         { U254MulScript::INPUT_SIZE },
         { U254MulScript::OUTPUT_SIZE },
@@ -268,6 +258,8 @@ fn test_u254_mul_disprove() -> eyre::Result<()> {
 
 #[test]
 fn test_u254_mul_payout() -> eyre::Result<()> {
+    color_eyre::install()?;
+    tracing_subscriber::fmt().init();
     test_script_payout_spending::<
         { U254MulScript::INPUT_SIZE },
         { U254MulScript::OUTPUT_SIZE },
@@ -276,7 +268,9 @@ fn test_u254_mul_payout() -> eyre::Result<()> {
 }
 
 #[test]
-fn test_square_fibonachi_disprove() -> eyre::Result<()> {
+fn test_square_fibonachi() -> eyre::Result<()> {
+    color_eyre::install()?;
+    tracing_subscriber::fmt().init();
     test_script_disprove_distorted::<
         { SquareFibonacciScript::<1024>::INPUT_SIZE },
         { SquareFibonacciScript::<1024>::OUTPUT_SIZE },
@@ -285,7 +279,10 @@ fn test_square_fibonachi_disprove() -> eyre::Result<()> {
 }
 
 #[test]
+#[ignore = "Stack size limit exceeded"]
 fn test_u32mul_disprove() -> eyre::Result<()> {
+    color_eyre::install()?;
+    tracing_subscriber::fmt().init();
     test_script_disprove_distorted::<
         { U32MulScript::INPUT_SIZE },
         { U32MulScript::OUTPUT_SIZE },


### PR DESCRIPTION
Add core types of transactions including Assert, Disprove and Payout spending. Add integration tests. Change u29mul to 32-bit multiplication.