### PR TITLE
:memo: Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+# :mag: Objective
+
+<!-- Describe the objective of this PR -->
+
+## :new: Added
+
+<!-- Describe what has been added (if no features are added, simply write "N/A") -->
+
+## :wrench: Fixed/Updated
+
+<!-- Describe what has been fixed or changed (if no previous functionality was changed, simply write "N/A") -->
+
+## :white_check_mark: Checklist
+
+- [] PR title corresponds to the body of changes.
+- [] PR has a proper label, assignee, and reviewers.
+- [] Tests that cover the changes are added (if needed).
+- [] Documentation (`README` files, paper) and Code Comments are updated accordingly.
+- [] Code is formatted, all tests pass, and CI shows no errors.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,8 @@
 
 ## :white_check_mark: Checklist
 
-- [] PR title corresponds to the body of changes.
-- [] PR has a proper label, assignee, and reviewers.
-- [] Tests that cover the changes are added (if needed).
-- [] Documentation (`README` files, paper) and Code Comments are updated accordingly.
-- [] Code is formatted, all tests pass, and CI shows no errors.
+- [ ] PR title corresponds to the body of changes.
+- [ ] PR has a proper label, assignee, and reviewers.
+- [ ] Tests that cover the changes are added (if needed).
+- [ ] Documentation (`README` files, paper) and Code Comments are updated accordingly.
+- [ ] Code is formatted, all tests pass, and CI shows no errors.


### PR DESCRIPTION
# :mag: Objective

To make managing PR easier, we add the template for PRs.

## :new: Added

Added `pull_request_template.md` file to the repository.

## :wrench: Fixed/Updated

N/A

## :white_check_mark: Checklist

- [x] PR title corresponds to the body of changes.
- [x] PR has a proper label, assignee, and reviewers.
- [x] Tests that cover the changes are added (if needed).
- [x] Documentation (`README` files, paper) and Code Comments are updated accordingly.
- [x] Code is formatted, all tests pass, and CI shows no errors.
